### PR TITLE
Follow up fixes for PR#84 and #86

### DIFF
--- a/gp-ant-task/src/main/java/com/ibm/g11n/pipeline/ant/GPBaseTask.java
+++ b/gp-ant-task/src/main/java/com/ibm/g11n/pipeline/ant/GPBaseTask.java
@@ -240,7 +240,7 @@ public abstract class GPBaseTask extends Task{
         String pkgName = parent == null ? "" :
             parent.getPath().replace(File.separatorChar, '.');
 
-        String fileName = f.getName();
+        String fileName = f.getName().replaceAll(" ", "_");
         if (type == ResourceType.JAVA) {
             int dotIdx = fileName.indexOf('.');
             if (dotIdx >= 0) {

--- a/gp-ant-task/src/main/java/com/ibm/g11n/pipeline/ant/GPDownloadTask.java
+++ b/gp-ant-task/src/main/java/com/ibm/g11n/pipeline/ant/GPDownloadTask.java
@@ -145,7 +145,7 @@ public class GPDownloadTask extends GPBaseTask {
                 if (outputSrcLang) {
                     if (bdlLangs.contains(srcLang)) {
                         exportLanguageResource(client, bf, srcLang, outDir,
-                                outContentOpt, bundleLayout, langIdStyle, langMap);
+                                outContentOpt, bundleLayout, langIdStyle, langMap, srcLang);
                     } else {
                         getProject().log("The specified source language (" + srcLang
                                 + ") does not exist in the bundle:" + bundleId, Project.MSG_WARN);
@@ -155,7 +155,7 @@ public class GPDownloadTask extends GPBaseTask {
                 for (String tgtLang: tgtLangs) {
                     if (bdlLangs.contains(tgtLang)) {
                         exportLanguageResource(client, bf, tgtLang, outDir,
-                                outContentOpt, bundleLayout, langIdStyle, langMap);
+                                outContentOpt, bundleLayout, langIdStyle, langMap, srcLang);
                     } else {
                         getProject().log("The specified target language (" + tgtLang
                                 + ") does not exist in the bundle:" + bundleId, Project.MSG_WARN);
@@ -175,11 +175,12 @@ public class GPDownloadTask extends GPBaseTask {
      * @param bundleLayout
      * @param langIdStyle
      * @param langMap
+     * @param srcLang
      * @throws BuildException
      */
     private void exportLanguageResource(ServiceClient client, SourceBundleFile bf, String language,
             File outBaseDir, OutputContentOption outContntOpt, BundleLayout bundleLayout,
-            LanguageIdStyle langIdStyle, Map<String, String> langMap)
+            LanguageIdStyle langIdStyle, Map<String, String> langMap, String srcLang)
                     throws BuildException {
         String srcFileName = bf.getFile().getName();
         String relPath = bf.getRelativePath();
@@ -189,14 +190,30 @@ public class GPDownloadTask extends GPBaseTask {
         switch (bundleLayout) {
         case LANGUAGE_SUFFIX: {
             File dir = (new File(outBaseDir, relPath)).getParentFile();
-            int idx = srcFileName.lastIndexOf('.');
-            String tgtName = null;
-            if (idx < 0) {
-                tgtName = srcFileName + "_" + getLanguageId(language, langIdStyle, langMap);
-            } else {
-                tgtName = srcFileName.substring(0, idx) + "_" + getLanguageId(language, langIdStyle, langMap)
-                + srcFileName.substring(idx);
+
+            String tgtName = srcFileName;
+            // Compose file name if the output language is not the source language
+            if (!language.equals(srcLang)) {
+                String baseName = srcFileName;
+                String extension = "";
+                int extensionIndex = srcFileName.lastIndexOf('.');
+                if (extensionIndex > 0) {
+                    baseName = srcFileName.substring(0, extensionIndex);
+                    extension = srcFileName.substring(extensionIndex);
+                }
+
+                // checks if the source file's base name (without extension) ends with
+                // source language code suffix, e.g. foo_en => foo
+                String srcLangSuffix = "_" + getLanguageId(srcLang, langIdStyle, langMap);
+                if (baseName.endsWith(srcLangSuffix)) {
+                    // truncates source the source language suffix from base name
+                    baseName = baseName.substring(0, baseName.length() - srcLangSuffix.length());
+                }
+
+                // append target language suffix to the base name, e.g. foo => foo_de
+                tgtName = baseName + "_" + getLanguageId(language, langIdStyle, langMap) + extension;
             }
+
             outputFile = new File(dir, tgtName);
             break;
         }

--- a/gp-maven-plugin/src/main/java/com/ibm/g11n/pipeline/maven/GPDownloadMojo.java
+++ b/gp-maven-plugin/src/main/java/com/ibm/g11n/pipeline/maven/GPDownloadMojo.java
@@ -163,22 +163,30 @@ public class GPDownloadMojo extends GPBaseMojo {
         switch (bundleLayout) {
         case LANGUAGE_SUFFIX: {
             File dir = (new File(outBaseDir, relPath)).getParentFile();
-            
-            // truncate source suffix from sourceFile name - BEGIN
-            int extensionIndex = srcFileName.lastIndexOf('.');
-            String extension = (extensionIndex > 0) ? srcFileName.substring(extensionIndex) : "";
-            int srcSuffixIndex = srcFileName.lastIndexOf("_" + getLanguageId(srcLang, langIdStyle, langMap));
-            srcFileName = (srcSuffixIndex > 0) ? srcFileName.substring(0,srcSuffixIndex) + extension : srcFileName;
-            // truncate source suffix from sourceFile name - END
-            
-            int idx = srcFileName.lastIndexOf('.');
-            String tgtName = null;
-            if (idx < 0) {
-                tgtName = srcFileName + "_" + getLanguageId(language, langIdStyle, langMap);
-            } else {
-                tgtName = srcFileName.substring(0, idx) + "_" + getLanguageId(language, langIdStyle, langMap)
-                    + srcFileName.substring(idx);
+
+            String tgtName = srcFileName;
+            // Compose file name if the output language is not the source language
+            if (!language.equals(srcLang)) {
+                String baseName = srcFileName;
+                String extension = "";
+                int extensionIndex = srcFileName.lastIndexOf('.');
+                if (extensionIndex > 0) {
+                    baseName = srcFileName.substring(0, extensionIndex);
+                    extension = srcFileName.substring(extensionIndex);
+                }
+
+                // checks if the source file's base name (without extension) ends with
+                // source language code suffix, e.g. foo_en => foo
+                String srcLangSuffix = "_" + getLanguageId(srcLang, langIdStyle, langMap);
+                if (baseName.endsWith(srcLangSuffix)) {
+                    // truncates source the source language suffix from base name
+                    baseName = baseName.substring(0, baseName.length() - srcLangSuffix.length());
+                }
+
+                // append target language suffix to the base name, e.g. foo => foo_de
+                tgtName = baseName + "_" + getLanguageId(language, langIdStyle, langMap) + extension;
             }
+
             outputFile = new File(dir, tgtName);
             break;
         }


### PR DESCRIPTION
Updated language suffix generation fix (PR#86) done in the GP maven plugin (skip file name processing when exporting source language, optimize target language suffix generation code ), and applied the same fix in GP ant task.

Also applied PR#84 space character in file path fix to GP ant task.