### PR TITLE
Rebranding to IBM Cloud, updating dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,8 @@ context as possible so we can try to recreate the issue.
 
 Do not submit account credentials in bug report forms.
 
-Use Bluemix support options within the Bluemix web page for customer
-assistance with Bluemix, including the Globalization Pipeline service itself.
+Use IBM Cloud support options within the IBM Cloud web page for customer
+assistance with IBM Cloud, including the Globalization Pipeline service itself.
 
 For general questions about Globalization Pipeline, you may also use the
 StackOverflow tag [“globalization pipeline”](http://stackoverflow.com/questions/tagged/globalization-pipeline)
@@ -49,14 +49,14 @@ change your rights to use your own Contributions for any other purpose.
 
 You can download the CLAs here:
 
- - [individual](https://github.com/IBM-Bluemix/gp-common/raw/master/legal/gp-cla-individual.pdf)
- - [corporate](https://github.com/IBM-Bluemix/gp-common/raw/master/legal/gp-cla-corporate.pdf)
+ - [individual](https://github.com/IBM-Cloud/gp-common/raw/master/legal/gp-cla-individual.pdf)
+ - [corporate](https://github.com/IBM-Cloud/gp-common/raw/master/legal/gp-cla-corporate.pdf)
 
 If you are an IBMer, please contact us directly as the contribution process is
 slightly different.
 
 ### Acknowledgement
 
-- Master copy: https://github.com/IBM-Bluemix/gp-common/blob/master/CONTRIBUTING.md
-- Copyright © 2016 IBM Corporation.
+- Master copy: https://github.com/IBM-Cloud/gp-common/blob/master/CONTRIBUTING.md
+- Copyright © 2016, 2018 IBM Corporation.
 - This document forked from [wasdev](https://github.com/WASdev/wasdev.github.io/blob/master/CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!--
 /*  
- * Copyright IBM Corp. 2016
+ * Copyright IBM Corp. 2016, 2018
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,16 +15,16 @@
  * limitations under the License.
  */
 -->
-Java Client Tools for Globalization Pipeline on IBM Bluemix
+Java Client Tools for IBM Globalization Pipeline
 ==
 
 # What is this?
 
 This repository contains Java tools for
-[Globalization Pipeline on IBM Bluemix](https://www.ng.bluemix.net/docs/services/GlobalizationPipeline/index.html).
+[IBM Globalization Pipeline](https://www.ng.bluemix.net/docs/services/GlobalizationPipeline/index.html).
 
-[![Build Status](https://travis-ci.org/IBM-Bluemix/gp-java-tools.svg?branch=master)](https://travis-ci.org/IBM-Bluemix/gp-java-tools)
-[![Coverage Status](https://coveralls.io/repos/github/IBM-Bluemix/gp-java-tools/badge.svg?branch=master)](https://coveralls.io/github/IBM-Bluemix/gp-java-tools?branch=master)
+[![Build Status](https://travis-ci.org/IBM-Cloud/gp-java-tools.svg?branch=master)](https://travis-ci.org/IBM-Cloud/gp-java-tools)
+[![Coverage Status](https://coveralls.io/repos/github/IBM-Cloud/gp-java-tools/badge.svg?branch=master)](https://coveralls.io/github/IBM-Cloud/gp-java-tools?branch=master)
 [![Coverity Scan](https://img.shields.io/coverity/scan/9398.svg)](https://scan.coverity.com/projects/ibm-bluemix-gp-java-tools)
 
 [![gp-java-tools](https://img.shields.io/maven-central/v/com.ibm.g11n.pipeline/gp-java-tools.svg)](#)
@@ -33,7 +33,7 @@ This repository contains Java tools for
 # Getting started
 
 To get started, you should familiarize yourself with the service itself. A good place
-to begin is by reading the [Quick Start Guide](https://github.com/IBM-Bluemix/gp-common#quick-start-guide) and the official [Getting Started with IBM Globalization ](https://www.ng.bluemix.net/docs/services/GlobalizationPipeline/index.html)
+to begin is by reading the [Quick Start Guide](https://github.com/IBM-Cloud/gp-common#quick-start-guide) and the official [Getting Started with IBM Globalization Pipeline](https://www.ng.bluemix.net/docs/services/GlobalizationPipeline/index.html)
 documentation.
 
 # Usage
@@ -77,7 +77,7 @@ information.
 
 # Community
 
-* View or file GitHub [Issues](https://github.com/IBM-Bluemix/gp-java-tools/issues)
+* View or file GitHub [Issues](https://github.com/IBM-Cloud/gp-java-tools/issues)
 * Connect with the open source community on [developerWorks Open](https://developer.ibm.com/open/ibm-bluemix-globalization-pipeline-service/)
 
 # Contributing

--- a/gp-ant-task/pom.xml
+++ b/gp-ant-task/pom.xml
@@ -24,12 +24,12 @@
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.4</version>
+			<version>2.6.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.g11n.pipeline</groupId>
 			<artifactId>gp-java-client</artifactId>
-			<version>1.1.3</version>
+			<version>1.1.5</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.g11n.pipeline</groupId>
@@ -43,7 +43,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>2.4.2</version>
+				<version>3.1.0</version>
 				<executions>
 					<execution>
 						<phase>package</phase>

--- a/gp-cli/pom.xml
+++ b/gp-cli/pom.xml
@@ -31,7 +31,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>2.4.2</version>
+				<version>3.1.0</version>
 				<executions>
 					<execution>
 						<phase>package</phase>
@@ -84,7 +84,7 @@
 		<dependency>
 			<groupId>com.beust</groupId>
 			<artifactId>jcommander</artifactId>
-			<version>1.48</version>
+			<version>1.72</version>
 		</dependency>
 
 		<dependency>
@@ -96,7 +96,7 @@
 		<dependency>
 			<groupId>com.ibm.g11n.pipeline</groupId>
 			<artifactId>gp-java-client</artifactId>
-			<version>1.1.3</version>
+			<version>1.1.5</version>
 		</dependency>
 
 		<dependency>

--- a/gp-maven-plugin/README.md
+++ b/gp-maven-plugin/README.md
@@ -68,7 +68,7 @@ in pom.xml.
             <plugin>
                 <groupId>com.ibm.g11n.pipeline</groupId>
                 <artifactId>gp-maven-plugin</artifactId>
-                <version>1.1.8</version>
+                <version>1.1.9</version>
             </plugin>
             [...]
         </plugins>

--- a/gp-maven-plugin/pom.xml
+++ b/gp-maven-plugin/pom.xml
@@ -128,7 +128,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-invoker-plugin</artifactId>
-						<version>2.0.0</version>
+						<version>3.0.1</version>
 						<configuration>
 							<debug>true</debug>
 							<addTestClassPath>true</addTestClassPath>
@@ -166,17 +166,17 @@
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-core</artifactId>
-			<version>3.0</version>
+			<version>3.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-plugin-api</artifactId>
-			<version>3.3.9</version>
+			<version>3.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.plugin-tools</groupId>
 			<artifactId>maven-plugin-annotations</artifactId>
-			<version>3.4</version>
+			<version>3.5</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -187,19 +187,19 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.8.2</version>
+			<version>4.12</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.4</version>
+			<version>2.6.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.g11n.pipeline</groupId>
 			<artifactId>gp-java-client</artifactId>
-			<version>1.1.3</version>
+			<version>1.1.5</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.g11n.pipeline</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -8,13 +8,13 @@
 	<packaging>pom</packaging>
 
 	<name>Globalization Pipeline Tools</name>
-	<description>Java client tools for Globalization Pipeline on IBM Bluemix.</description>
+	<description>Java client tools for IBM Globalization Pipeline.</description>
 
         <properties>
           <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         </properties>
 
-	<url>https://github.com/IBM-Bluemix/gp-java-tools</url>
+	<url>https://github.com/IBM-Cloud/gp-java-tools</url>
 
 	<licenses>
 		<license>
@@ -33,9 +33,9 @@
 	</developers>
 
 	<scm>
-		<connection>scm:git:git@github.com:IBM-Bluemix/gp-java-tools.git</connection>
-		<developerConnection>scm:git:git@github.com:IBM-Bluemix/gp-java-tools.git</developerConnection>
-		<url>git@github.com:IBM-Bluemix/gp-java-tools.git</url>
+		<connection>scm:git:git@github.com:IBM-Cloud/gp-java-tools.git</connection>
+		<developerConnection>scm:git:git@github.com:IBM-Cloud/gp-java-tools.git</developerConnection>
+		<url>git@github.com:IBM-Cloud/gp-java-tools.git</url>
 		<tag>HEAD</tag>
 	</scm>
 
@@ -56,7 +56,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-dependency-plugin</artifactId>
-					<version>2.10</version>
+					<version>3.0.2</version>
 					<executions>
 						<execution>
 							<id>analyze</id>
@@ -74,7 +74,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.6.0</version>
+					<version>3.7.0</version>
 					<configuration>
 						<source>1.7</source>
 						<target>1.7</target>
@@ -85,7 +85,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>2.10.4</version>
+					<version>3.0.0</version>
 					<configuration>
 						<encoding>UTF-8</encoding>
 					</configuration>
@@ -132,7 +132,7 @@
 						<plugin>
 							<groupId>org.apache.maven.plugins</groupId>
 							<artifactId>maven-source-plugin</artifactId>
-							<version>2.4</version>
+							<version>3.0.1</version>
 							<executions>
 								<execution>
 									<id>attach-sources</id>


### PR DESCRIPTION
Replaced the term Bluemix with IBM Cloud. Updated repository links in various places.
The Coverity project name is still IBM-Bluemix/gp-java-tools in .travis.yml is not modified yet (need some changes on coverity side?)

Also updated dependency component versions, mostly latest for each at this moment.

Fixes #88.