### PR TITLE
Handle exception while parsing Java resource string

### DIFF
--- a/gp-res-filter/src/main/java/com/ibm/g11n/pipeline/resfilter/impl/JavaPropertiesResource.java
+++ b/gp-res-filter/src/main/java/com/ibm/g11n/pipeline/resfilter/impl/JavaPropertiesResource.java
@@ -627,7 +627,19 @@ public class JavaPropertiesResource extends ResourceFilter {
     public static String ConvertDoubleSingleQuote(String inputStr){
         String outputStr = "";
         boolean needConvert = false;
-        MessagePattern msgPat = new MessagePattern(inputStr);
+        MessagePattern msgPat = null;
+        try {
+            msgPat = new MessagePattern(inputStr);
+        } catch (IllegalArgumentException e) {
+            // not a message format pattern - fall through
+        } catch (IndexOutOfBoundsException e) {
+            // might be a valid message format pattern, but cannot handle this - fall through
+        }
+        if (msgPat == null) {
+            // if the string cannot be parsed as a MessageFormat pattern string,
+            // just returns the input string.
+            return inputStr;
+        }
 
         int numParts = msgPat.countParts();
 

--- a/gp-res-filter/src/test/java/com/ibm/g11n/pipeline/resfilter/impl/JavaPropertiesResourceTest.java
+++ b/gp-res-filter/src/test/java/com/ibm/g11n/pipeline/resfilter/impl/JavaPropertiesResourceTest.java
@@ -91,10 +91,13 @@ public class JavaPropertiesResourceTest {
 
         lst.add(ResourceString.with("withTabs", "Tab1\tTab2\tTab3\t").sequenceNumber(9)
                 .notes(Arrays.asList(" tabs")).build());
-        
+
         lst.add(ResourceString.with("withQuote", "You're about to delete '{0}' rows in Mike's file {0}.")
                 .sequenceNumber(10).notes(Arrays.asList(" Quote")).build());
-        
+
+        lst.add(ResourceString.with("non-param", "This {} is not a parameter.")
+                .sequenceNumber(11).notes(Arrays.asList(" Not a Java MessageFormat param")).build());
+
         Collections.sort(lst, new ResourceStringComparator());
         EXPECTED_INPUT_RES_LIST = lst;
     }
@@ -123,6 +126,8 @@ public class JavaPropertiesResourceTest {
                 Arrays.asList(" tabs"));
         bundleBuilder.addResourceString("withQuote", "You're about to delete '{1}' rows in Mike's file {0}.", 10,
                 Arrays.asList(" Quote"));
+        bundleBuilder.addResourceString("non-param", "This {} is not a parameter.", 11,
+                Arrays.asList(" Not a Java MessageFormat param"));
         bundleBuilder.addNotes(Arrays.asList(
                 " You are reading the \".properties\" entry.",
                 " The exclamation mark can also mark text as comments.",
@@ -145,6 +150,9 @@ public class JavaPropertiesResourceTest {
         EXPECTED_PROP_DEF_LIST.add(new PropDef("leadTabs", "leading tabs", PropSeparator.EQUAL));
         EXPECTED_PROP_DEF_LIST.add(new PropDef("trailSPs", "trailing SPs  ", PropSeparator.EQUAL));
         EXPECTED_PROP_DEF_LIST.add(new PropDef("withTabs", "Tab1\tTab2\tTab3\t", PropSeparator.EQUAL));
+        // PropDef does not detect message pattern - message pattern handling is done by the logic in JavaPropertiesResource class
+        EXPECTED_PROP_DEF_LIST.add(new PropDef("withQuote", "You''re about to delete '{1}' rows in Mike''s file {0}.", PropSeparator.EQUAL));
+        EXPECTED_PROP_DEF_LIST.add(new PropDef("non-param", "This {} is not a parameter.", PropSeparator.EQUAL));
     }
 
     private static final JavaPropertiesResource res = new JavaPropertiesResource();

--- a/gp-res-filter/src/test/resource/resfilter/properties/input.properties
+++ b/gp-res-filter/src/test/resource/resfilter/properties/input.properties
@@ -23,3 +23,5 @@ trailSPs = trailing SPs
 withTabs = Tab1\tTab2\tTab3\t
 # Quote
 withQuote = You''re about to delete '{0}' rows in Mike''s file {0}.
+# Not a Java MessageFormat param
+non-param = This {} is not a parameter.

--- a/gp-res-filter/src/test/resource/resfilter/properties/merge-output.properties
+++ b/gp-res-filter/src/test/resource/resfilter/properties/merge-output.properties
@@ -23,3 +23,5 @@ trailSPs = localized trailing SPs
 withTabs = localized Tab1\tTab2\tTab3\t
 # Quote
 withQuote = You''re about to delete '{1}' rows in Mike''s file {0}.
+# Not a Java MessageFormat param
+non-param = This {} is not a parameter.

--- a/gp-res-filter/src/test/resource/resfilter/properties/parse-test-input.properties
+++ b/gp-res-filter/src/test/resource/resfilter/properties/parse-test-input.properties
@@ -7,3 +7,5 @@ tab : pick up the\u00A5 tab
 		leadTabs = leading tabs
 trailSPs = trailing SPs  
 withTabs = Tab1\tTab2\tTab3\t
+withQuote = You''re about to delete '{1}' rows in Mike''s file {0}.
+non-param = This {} is not a parameter.

--- a/gp-res-filter/src/test/resource/resfilter/properties/parseline-test-input.properties
+++ b/gp-res-filter/src/test/resource/resfilter/properties/parseline-test-input.properties
@@ -7,3 +7,5 @@ leadSPs = leading SPs
 leadTabs = leading tabs
 trailSPs = trailing SPs  
 withTabs = Tab1\tTab2\tTab3\t
+withQuote = You''re about to delete '{1}' rows in Mike''s file {0}.
+non-param = This {} is not a parameter.

--- a/gp-res-filter/src/test/resource/resfilter/properties/write-output.properties
+++ b/gp-res-filter/src/test/resource/resfilter/properties/write-output.properties
@@ -24,3 +24,5 @@ trailSPs = localized trailing SPs
 withTabs = localized Tab1\tTab2\tTab3\t
 # Quote
 withQuote = You''re about to delete '{1}' rows in Mike''s file {0}.
+# Not a Java MessageFormat param
+non-param = This {} is not a parameter.


### PR DESCRIPTION
MessagePattern class throws an exception when a given string is not
parsed as a valid message format pattern string. Added exception
handling code in the code unescaping single quote in an input resource
string. When an exception was thrown by MessagePattern class, we don’t
need to unescape single quotes, because it’s not a message format
pattern.

Fixes #99