### PR TITLE
Fix numeric keys

### DIFF
--- a/gp-res-filter/src/main/java/com/ibm/g11n/pipeline/resfilter/impl/JsonResource.java
+++ b/gp-res-filter/src/main/java/com/ibm/g11n/pipeline/resfilter/impl/JsonResource.java
@@ -54,7 +54,7 @@ import com.ibm.g11n.pipeline.resfilter.ResourceString;
  */
 public class JsonResource extends ResourceFilter {
 
-    private class KeyPiece {
+    static class KeyPiece {
         String keyValue;
         JsonToken keyType;
 
@@ -248,10 +248,10 @@ public class JsonResource extends ResourceFilter {
         }
     }
 
-    private List<KeyPiece> splitKeyPieces(String key) {
+    static List<KeyPiece> splitKeyPieces(String key) {
         if (USE_JSONPATH_PATTERN.matcher(key).matches()) {
             List<KeyPiece> result = new ArrayList<KeyPiece>();
-            Matcher onlyDigits = Pattern.compile("^\\d+$").matcher("");
+             Matcher onlyDigits = Pattern.compile("^\\d+$").matcher("");
             // Disregard $ at the beginning - it's not really part of the key...
             List<String> tokens = findTokens(key.substring(JSONPATH_ROOT.length()));
             for (String s : tokens) {
@@ -259,8 +259,10 @@ public class JsonResource extends ResourceFilter {
                     // Turn any "\u0027" in the key back into '
                     String modifiedKeyPiece = s.substring(1, s.length() - 1).replaceAll("\\\\u0027", "'");
                     result.add(new KeyPiece(modifiedKeyPiece, JsonToken.BEGIN_OBJECT));
-                } else if (onlyDigits.reset(s).matches()) {
+                } else if (onlyDigits.reset(s).matches()) { // BAD
                     result.add(new KeyPiece(s, JsonToken.BEGIN_ARRAY));
+                } else if (false && s.startsWith("[") && (s.length() > 1)) {
+                    result.add(new KeyPiece(s.substring(1, s.length() - 1), JsonToken.BEGIN_ARRAY));
                 } else {
                     for (String s2 : s.split("\\.")) {
                         if (!s2.isEmpty()) {
@@ -275,7 +277,7 @@ public class JsonResource extends ResourceFilter {
         return Collections.singletonList(new KeyPiece(key, JsonToken.BEGIN_OBJECT));
     }
 
-    private static List<String> findTokens(String data) {
+    static List<String> findTokens(String data) {
         List<String> tokens = new ArrayList<String>();
         boolean inQuotes = false;
         StringBuilder currentToken = new StringBuilder();
@@ -286,10 +288,16 @@ public class JsonResource extends ResourceFilter {
                 inQuotes = !inQuotes;
             }
             if (!inQuotes && (c == '.' || c == '[' || c == ']')) {
+                // if (c == ']') {
+                // currentToken.append(c);
+                // }
                 if (currentToken.length() > 0) {
                     tokens.add(currentToken.toString());
                     currentToken.setLength(0);
                 }
+                // if (c == '[') {
+                // currentToken.append(c);
+                // }
             } else {
                 currentToken.append(c);
             }

--- a/gp-res-filter/src/test/java/com/ibm/g11n/pipeline/resfilter/impl/JsonResourceTest.java
+++ b/gp-res-filter/src/test/java/com/ibm/g11n/pipeline/resfilter/impl/JsonResourceTest.java
@@ -15,7 +15,7 @@
  */
 package com.ibm.g11n.pipeline.resfilter.impl;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -44,6 +44,7 @@ import com.ibm.g11n.pipeline.resfilter.ResourceString.ResourceStringComparator;
  */
 public class JsonResourceTest {
     private static final File INPUT_FILE = new File("src/test/resource/resfilter/json/input.json");
+    private static final File INPUT_FILE2 = new File("src/test/resource/resfilter/json/other-input.json");
 
     private static final File EXPECTED_WRITE_FILE = new File("src/test/resource/resfilter/json/write-output.json");
 
@@ -62,8 +63,10 @@ public class JsonResourceTest {
         lst.add(ResourceString.with("$.countries[1].Asia[1]", "Japan").sequenceNumber(9).build());
         lst.add(ResourceString.with("$.countries[1].Asia[2]", "India").sequenceNumber(10).build());
         lst.add(ResourceString.with("$.countries[2].Americas['S. America'][0]", "Brazil").sequenceNumber(11).build());
-        lst.add(ResourceString.with("$.countries[2].Americas['S. America'][1]", "Venezuela").sequenceNumber(12).build());
-        lst.add(ResourceString.with("$.countries[2].Americas['N. America'][0]", "United States [USA]").sequenceNumber(13).build());
+        lst.add(ResourceString.with("$.countries[2].Americas['S. America'][1]", "Venezuela").sequenceNumber(12)
+                .build());
+        lst.add(ResourceString.with("$.countries[2].Americas['N. America'][0]", "United States [USA]")
+                .sequenceNumber(13).build());
         lst.add(ResourceString.with("$.countries[2].Americas['N. America'][1]", "Canada").sequenceNumber(14).build());
         lst.add(ResourceString.with("$.countries[2].Americas['N. America'][2]", "Mexico").sequenceNumber(15).build());
         lst.add(ResourceString.with("$.countries[3].Africa[0]", "Egypt").sequenceNumber(16).build());
@@ -77,10 +80,14 @@ public class JsonResourceTest {
         lst.add(ResourceString.with("another.text", "Another plain old string").sequenceNumber(24).build());
         lst.add(ResourceString.with("frog['2']", "Red-eyed Tree Frog").sequenceNumber(25).build());
         lst.add(ResourceString.with("owl[3]", "Great Horned Owl").sequenceNumber(26).build());
-        lst.add(ResourceString.with("$['$.xxx']", "Looks like JSONPATH, but actually plain old string").sequenceNumber(27).build());
-        lst.add(ResourceString.with("$['$.']", "Looks like JSONPATH prefix, but actually plain old string").sequenceNumber(28).build());
-        lst.add(ResourceString.with("$abc", "Starts with JSONPATH root char, but just a string").sequenceNumber(29).build());
-        lst.add(ResourceString.with("$['ibm.com']['g11n.pipeline.title']", "Globalization Pipeline").sequenceNumber(30).build());
+        lst.add(ResourceString.with("$['$.xxx']", "Looks like JSONPATH, but actually plain old string")
+                .sequenceNumber(27).build());
+        lst.add(ResourceString.with("$['$.']", "Looks like JSONPATH prefix, but actually plain old string")
+                .sequenceNumber(28).build());
+        lst.add(ResourceString.with("$abc", "Starts with JSONPATH root char, but just a string").sequenceNumber(29)
+                .build());
+        lst.add(ResourceString.with("$['ibm.com']['g11n.pipeline.title']", "Globalization Pipeline").sequenceNumber(30)
+                .build());
 
         Collections.sort(lst, new ResourceStringComparator());
         EXPECTED_INPUT_RES_LIST = lst;
@@ -117,7 +124,8 @@ public class JsonResourceTest {
         bundleBuilder.addResourceString("frog['2']", "Red-eyed Tree Frog - XL", 25);
         bundleBuilder.addResourceString("owl[3]", "Great Horned Owl - XL", 26);
         bundleBuilder.addResourceString("$['$.xxx']", "Looks like JSONPATH, but actually plain old string - XL", 27);
-        bundleBuilder.addResourceString("$['$.']", "Looks like JSONPATH prefix, but actually plain old string - XL", 28);
+        bundleBuilder.addResourceString("$['$.']", "Looks like JSONPATH prefix, but actually plain old string - XL",
+                28);
         bundleBuilder.addResourceString("$abc", "Starts with JSONPATH root char, but just a string - XL", 29);
         bundleBuilder.addResourceString("$['ibm.com']['g11n.pipeline.title']", "Globalization Pipeline - XL", 30);
         WRITE_BUNDLE = bundleBuilder.build();
@@ -133,7 +141,8 @@ public class JsonResourceTest {
             LanguageBundle bundle = res.parse(is, null);
             List<ResourceString> resStrList = new ArrayList<>(bundle.getResourceStrings());
             Collections.sort(resStrList, new ResourceStringComparator());
-            assertEquals("ResourceStrings did not match.", EXPECTED_INPUT_RES_LIST, resStrList);
+            assertArrayEquals("ResourceStrings did not match.", EXPECTED_INPUT_RES_LIST.toArray(),
+                    resStrList.toArray());
         }
     }
 
@@ -145,12 +154,71 @@ public class JsonResourceTest {
         try (OutputStream os = new FileOutputStream(tempFile)) {
             res.write(os, WRITE_BUNDLE, null);
             os.flush();
-            assertTrue(ResourceTestUtil.compareFiles(EXPECTED_WRITE_FILE, tempFile));
+            ResourceTestUtil.compareFilesJson(EXPECTED_WRITE_FILE, tempFile);
+        }
+    }
+
+    // @Test
+    // public void testTestFiles() throws IOException, ResourceFilterException {
+    // // just test the test files
+    // ResourceTestUtil.compareFilesJson(INPUT_FILE, EXPECTED_WRITE_FILE);
+    // }
+
+    @Test
+    public void testReWrite() throws IOException, ResourceFilterException {
+        // First parse
+        assertTrue("The input test file <" + INPUT_FILE + "> does not exist.", INPUT_FILE.exists());
+
+        try (InputStream is = new FileInputStream(INPUT_FILE)) {
+            JsonResource res2 = new JsonResource();
+            LanguageBundle bundle = res2.parse(is, null);
+            List<ResourceString> resStrList = new ArrayList<>(bundle.getResourceStrings());
+            Collections.sort(resStrList, new ResourceStringComparator());
+            assertArrayEquals("ResourceStrings did not match.", EXPECTED_INPUT_RES_LIST.toArray(),
+                    resStrList.toArray());
+
+            // Now write
+            File tempFile = File.createTempFile(this.getClass().getSimpleName(), "2.json");
+            // File tempFile = new File("/tmp/2.json");
+            tempFile.deleteOnExit();
+
+            try (OutputStream os = new FileOutputStream(tempFile)) {
+                res.write(os, bundle, null);
+                os.flush();
+                ResourceTestUtil.compareFilesJson(INPUT_FILE, tempFile);
+            }
+        }
+    }
+
+    @Test
+    public void testReWriteOther() throws IOException, ResourceFilterException {
+        // First parse
+        assertTrue("The input test file <" + INPUT_FILE + "> does not exist.", INPUT_FILE2.exists());
+
+        try (InputStream is = new FileInputStream(INPUT_FILE2)) {
+            JsonResource res2 = new JsonResource();
+            LanguageBundle bundle = res2.parse(is, null);
+            List<ResourceString> resStrList = new ArrayList<>(bundle.getResourceStrings());
+            Collections.sort(resStrList, new ResourceStringComparator());
+            // assertEquals("ResourceStrings did not match.",
+            // EXPECTED_INPUT_RES_LIST, resStrList);
+
+            // Now write
+            File tempFile = File.createTempFile(this.getClass().getSimpleName(), "3.json");
+            // File tempFile = new File("/tmp/3.json");
+            tempFile.deleteOnExit();
+
+            try (OutputStream os = new FileOutputStream(tempFile)) {
+                res.write(os, bundle, null);
+                os.flush();
+                System.out.println(ResourceTestUtil.fileToString(tempFile));
+                ResourceTestUtil.compareFilesJson(INPUT_FILE2, tempFile);
+            }
         }
     }
 
     // TODO: Not ready yet
-//    @Test
-//    public void testMerge() throws IOException, ResourceFilterException {
-//    }
+    // @Test
+    // public void testMerge() throws IOException, ResourceFilterException {
+    // }
 }

--- a/gp-res-filter/src/test/java/com/ibm/g11n/pipeline/resfilter/impl/ResourceTestUtil.java
+++ b/gp-res-filter/src/test/java/com/ibm/g11n/pipeline/resfilter/impl/ResourceTestUtil.java
@@ -16,6 +16,7 @@
 
 package com.ibm.g11n.pipeline.resfilter.impl;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import java.io.BufferedReader;
@@ -23,8 +24,12 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.Reader;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
 
 /**
  * @author farhan, JCEmmons
@@ -76,11 +81,13 @@ public class ResourceTestUtil {
 
         return true;
     }
+
     /**
      * Returns true if the two files match exactly up to the number of lines
-     * specified in n 
+     * specified in n
      */
-    public static boolean compareFilesUpTo(File expected, File actual, int n) throws FileNotFoundException, IOException {
+    public static boolean compareFilesUpTo(File expected, File actual, int n)
+            throws FileNotFoundException, IOException {
         try (BufferedReader expectedRdr = new BufferedReader(new FileReader(expected));
                 BufferedReader actualRdr = new BufferedReader(new FileReader(actual))) {
 
@@ -123,5 +130,27 @@ public class ResourceTestUtil {
     public static String fileToString(File file) throws FileNotFoundException, IOException {
         byte[] encoded = Files.readAllBytes(Paths.get(file.getPath()));
         return new String(encoded, "UTF-8");
+    }
+
+    /**
+     * @param expectedWriteFile
+     * @param tempFile
+     * @return
+     * @throws IOException
+     * @throws FileNotFoundException
+     */
+    public static void compareFilesJson(File expectedWriteFile, File tempFile)
+            throws FileNotFoundException, IOException {
+        JsonElement expected = parseJson(expectedWriteFile);
+        JsonElement actual = parseJson(tempFile);
+        assertEquals("JSON mismatch: " + tempFile.getName() + " did not match " + expectedWriteFile.getName(), expected,
+                actual);
+    }
+
+    public static JsonElement parseJson(final File f) throws FileNotFoundException, IOException {
+        try (final Reader reader = new FileReader(f)) {
+            JsonElement parse = new JsonParser().parse(reader);
+            return parse;
+        }
     }
 }

--- a/gp-res-filter/src/test/resource/resfilter/json/other-input.json
+++ b/gp-res-filter/src/test/resource/resfilter/json/other-input.json
@@ -1,0 +1,6 @@
+{
+	"hello": {
+		"1": "Firstly",
+		"two": "Secondly"
+	}
+}

--- a/gp-res-filter/src/test/resource/resfilter/json/testSplitKeys.json
+++ b/gp-res-filter/src/test/resource/resfilter/json/testSplitKeys.json
@@ -1,0 +1,432 @@
+{
+	"$.firstly.1": [
+		{
+			"keyValue": "firstly",
+			"keyType": "BEGIN_OBJECT"
+		},
+		{
+			"keyValue": "1",
+			"keyType": "BEGIN_OBJECT"
+		}
+	],
+    "$.bears.grizzly.black": [
+        {
+            "keyValue": "bears",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "grizzly",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "black",
+            "keyType": "BEGIN_OBJECT"
+        }
+    ],
+    "$.bears.grizzly.brown": [
+        {
+            "keyValue": "bears",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "grizzly",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "brown",
+            "keyType": "BEGIN_OBJECT"
+        }
+    ],
+    "$.bears.white": [
+        {
+            "keyValue": "bears",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "white",
+            "keyType": "BEGIN_OBJECT"
+        }
+    ],
+    "$.colors[0]": [
+        {
+            "keyValue": "colors",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "0",
+            "keyType": "BEGIN_ARRAY"
+        }
+    ],
+    "$.colors[1]": [
+        {
+            "keyValue": "colors",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "1",
+            "keyType": "BEGIN_ARRAY"
+        }
+    ],
+    "$.colors[2]": [
+        {
+            "keyValue": "colors",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "2",
+            "keyType": "BEGIN_ARRAY"
+        }
+    ],
+    "$.colors[3]": [
+        {
+            "keyValue": "colors",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "3",
+            "keyType": "BEGIN_ARRAY"
+        }
+    ],
+    "$.countries[0].Europe[0]": [
+        {
+            "keyValue": "countries",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "0",
+            "keyType": "BEGIN_ARRAY"
+        },
+        {
+            "keyValue": "Europe",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "0",
+            "keyType": "BEGIN_ARRAY"
+        }
+    ],
+    "$.countries[0].Europe[1]": [
+        {
+            "keyValue": "countries",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "0",
+            "keyType": "BEGIN_ARRAY"
+        },
+        {
+            "keyValue": "Europe",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "1",
+            "keyType": "BEGIN_ARRAY"
+        }
+    ],
+    "$.countries[0].Europe[2]": [
+        {
+            "keyValue": "countries",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "0",
+            "keyType": "BEGIN_ARRAY"
+        },
+        {
+            "keyValue": "Europe",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "2",
+            "keyType": "BEGIN_ARRAY"
+        }
+    ],
+    "$.countries[0].Europe[3]": [
+        {
+            "keyValue": "countries",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "0",
+            "keyType": "BEGIN_ARRAY"
+        },
+        {
+            "keyValue": "Europe",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "3",
+            "keyType": "BEGIN_ARRAY"
+        }
+    ],
+    "$.countries[1].Asia[0]": [
+        {
+            "keyValue": "countries",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "1",
+            "keyType": "BEGIN_ARRAY"
+        },
+        {
+            "keyValue": "Asia",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "0",
+            "keyType": "BEGIN_ARRAY"
+        }
+    ],
+    "$.countries[1].Asia[1]": [
+        {
+            "keyValue": "countries",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "1",
+            "keyType": "BEGIN_ARRAY"
+        },
+        {
+            "keyValue": "Asia",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "1",
+            "keyType": "BEGIN_ARRAY"
+        }
+    ],
+    "$.countries[1].Asia[2]": [
+        {
+            "keyValue": "countries",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "1",
+            "keyType": "BEGIN_ARRAY"
+        },
+        {
+            "keyValue": "Asia",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "2",
+            "keyType": "BEGIN_ARRAY"
+        }
+    ],
+    "$.countries[2].Americas['N. America'][0]": [
+        {
+            "keyValue": "countries",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "2",
+            "keyType": "BEGIN_ARRAY"
+        },
+        {
+            "keyValue": "Americas",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "N. America",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "0",
+            "keyType": "BEGIN_ARRAY"
+        }
+    ],
+    "$.countries[2].Americas['N. America'][1]": [
+        {
+            "keyValue": "countries",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "2",
+            "keyType": "BEGIN_ARRAY"
+        },
+        {
+            "keyValue": "Americas",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "N. America",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "1",
+            "keyType": "BEGIN_ARRAY"
+        }
+    ],
+    "$.countries[2].Americas['N. America'][2]": [
+        {
+            "keyValue": "countries",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "2",
+            "keyType": "BEGIN_ARRAY"
+        },
+        {
+            "keyValue": "Americas",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "N. America",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "2",
+            "keyType": "BEGIN_ARRAY"
+        }
+    ],
+    "$.countries[2].Americas['S. America'][0]": [
+        {
+            "keyValue": "countries",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "2",
+            "keyType": "BEGIN_ARRAY"
+        },
+        {
+            "keyValue": "Americas",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "S. America",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "0",
+            "keyType": "BEGIN_ARRAY"
+        }
+    ],
+    "$.countries[2].Americas['S. America'][1]": [
+        {
+            "keyValue": "countries",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "2",
+            "keyType": "BEGIN_ARRAY"
+        },
+        {
+            "keyValue": "Americas",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "S. America",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "1",
+            "keyType": "BEGIN_ARRAY"
+        }
+    ],
+    "$.countries[3].Africa[0]": [
+        {
+            "keyValue": "countries",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "3",
+            "keyType": "BEGIN_ARRAY"
+        },
+        {
+            "keyValue": "Africa",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "0",
+            "keyType": "BEGIN_ARRAY"
+        }
+    ],
+    "$.countries[3].Africa[1]": [
+        {
+            "keyValue": "countries",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "3",
+            "keyType": "BEGIN_ARRAY"
+        },
+        {
+            "keyValue": "Africa",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "1",
+            "keyType": "BEGIN_ARRAY"
+        }
+    ],
+    "$.countries[3].Africa[2]": [
+        {
+            "keyValue": "countries",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "3",
+            "keyType": "BEGIN_ARRAY"
+        },
+        {
+            "keyValue": "Africa",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "2",
+            "keyType": "BEGIN_ARRAY"
+        }
+    ],
+    "$['$.']": [
+        {
+            "keyValue": "$.",
+            "keyType": "BEGIN_OBJECT"
+        }
+    ],
+    "$['$.xxx']": [
+        {
+            "keyValue": "$.xxx",
+            "keyType": "BEGIN_OBJECT"
+        }
+    ],
+    "$['ibm.com']['g11n.pipeline.title']": [
+        {
+            "keyValue": "ibm.com",
+            "keyType": "BEGIN_OBJECT"
+        },
+        {
+            "keyValue": "g11n.pipeline.title",
+            "keyType": "BEGIN_OBJECT"
+        }
+    ],
+    "$abc": [
+        {
+            "keyValue": "$abc",
+            "keyType": "BEGIN_OBJECT"
+        }
+    ],
+    "another.text": [
+        {
+            "keyValue": "another.text",
+            "keyType": "BEGIN_OBJECT"
+        }
+    ],
+    "frog['2']": [
+        {
+            "keyValue": "frog['2']",
+            "keyType": "BEGIN_OBJECT"
+        }
+    ],
+    "owl[3]": [
+        {
+            "keyValue": "owl[3]",
+            "keyType": "BEGIN_OBJECT"
+        }
+    ],
+    "some_text": [
+        {
+            "keyValue": "some_text",
+            "keyType": "BEGIN_OBJECT"
+        }
+    ]
+}


### PR DESCRIPTION
Fixes: #103 

verifies compatibility with splitKeys  and round trip of prior resources

For key `$.foo.1`  the `1` is now properly understood as a key, not an array index.