### PR TITLE
Fixed Java properties file parsing problem

### DIFF
--- a/gp-cli/README.md
+++ b/gp-cli/README.md
@@ -160,6 +160,8 @@ There are several different resource types available:
 
 * **JAVA** - Java property resource bundle file
 * **JAVAUTF8** - Java UTF8 property resource bundle file
+* **JAVAMSG** - Java property resource bundle file with MessageFormat pattern stirngs only
+* **JAVAMSGUTF8** - Java UTF8 property resource bundle file with MessageFormat pattern strings only
 * **JSON** - Resource string key/value pairs stored in JSON format. For now nested JSON object is not supported.
 * **AMDJS** - RequireJS I18N bundle file
 * **GLOBALIZEJS** - Globalize.js JSON resource bundle file

--- a/gp-maven-plugin/README.md
+++ b/gp-maven-plugin/README.md
@@ -412,6 +412,9 @@ excludes all files with file name `config.json`.
 Specifies a resource type. Available options are
 
 * **JAVA** - Java property resource bundle file
+* **JAVAUTF8** - Java UTF8 property resource bundle file
+* **JAVAMSG** - Java property resource bundle file with MessageFormat pattern stirngs only
+* **JAVAMSGUTF8** - Java UTF8 property resource bundle file with MessageFormat pattern strings only
 * **JSON** - Resource string key/value pairs stored in JSON format. For now nested JSON object is not supported.
 * **AMDJS** - RequireJS I18N bundle file
 * **GLOBALIZEJS** - Globalize.js JSON resource bundle file

--- a/gp-res-filter/src/main/java/com/ibm/g11n/pipeline/resfilter/impl/DefaultResourceFilterProvider.java
+++ b/gp-res-filter/src/main/java/com/ibm/g11n/pipeline/resfilter/impl/DefaultResourceFilterProvider.java
@@ -25,6 +25,8 @@ import com.ibm.g11n.pipeline.resfilter.FilterInfo.Type;
 import com.ibm.g11n.pipeline.resfilter.MultiBundleResourceFilter;
 import com.ibm.g11n.pipeline.resfilter.ResourceFilter;
 import com.ibm.g11n.pipeline.resfilter.ResourceFilterProvider;
+import com.ibm.g11n.pipeline.resfilter.impl.JavaPropertiesResource.Encoding;
+import com.ibm.g11n.pipeline.resfilter.impl.JavaPropertiesResource.MessagePatternEscape;
 
 /**
  * The default {@link ResourceFilterProvider} implementation.
@@ -38,6 +40,8 @@ public class DefaultResourceFilterProvider extends ResourceFilterProvider {
         GLOBALIZEJS,
         IOS,
         JAVA,
+        JAVAMSG,
+        JAVAMSGUTF8,
         JAVAUTF8,
         JSON,
         PO,
@@ -90,10 +94,16 @@ public class DefaultResourceFilterProvider extends ResourceFilterProvider {
             result = new IOSStringsResource();
             break;
         case JAVA:
-            result = new JavaPropertiesResource(false);
+            result = new JavaPropertiesResource(Encoding.ISO_8859_1, MessagePatternEscape.AUTO);
+            break;
+        case JAVAMSG:
+            result = new JavaPropertiesResource(Encoding.ISO_8859_1, MessagePatternEscape.ALL);
+            break;
+        case JAVAMSGUTF8:
+            result = new JavaPropertiesResource(Encoding.UTF_8, MessagePatternEscape.ALL);
             break;
         case JAVAUTF8:
-            result = new JavaPropertiesResource(true);
+            result = new JavaPropertiesResource(Encoding.UTF_8, MessagePatternEscape.AUTO);
             break;
         case JSON:
             result = new JsonResource();

--- a/gp-res-filter/src/test/java/com/ibm/g11n/pipeline/resfilter/impl/JavaPropertiesResourceTest.java
+++ b/gp-res-filter/src/test/java/com/ibm/g11n/pipeline/resfilter/impl/JavaPropertiesResourceTest.java
@@ -42,6 +42,7 @@ import com.ibm.g11n.pipeline.resfilter.LanguageBundleBuilder;
 import com.ibm.g11n.pipeline.resfilter.ResourceFilterException;
 import com.ibm.g11n.pipeline.resfilter.ResourceString;
 import com.ibm.g11n.pipeline.resfilter.ResourceString.ResourceStringComparator;
+import com.ibm.g11n.pipeline.resfilter.impl.JavaPropertiesResource.MessagePatternEscape;
 import com.ibm.g11n.pipeline.resfilter.impl.JavaPropertiesResource.PropDef;
 import com.ibm.g11n.pipeline.resfilter.impl.JavaPropertiesResource.PropDef.PropSeparator;
 
@@ -308,7 +309,6 @@ public class JavaPropertiesResourceTest {
     
     private static final String[][] QUOTES_TEST_CASES =
         {
-                {"It's not a bug.","It's not a bug."},
                 {"You're about to delete {0} rows.","You''re about to delete {0} rows."},
                 {"You're about to delete '{0}' rows in Mike's file {0}.","You''re about to delete '{0}' rows in Mike''s file {0}."},
                 {"Log shows '{''}' in file {0}","Log shows '{''}' in file {0}"},
@@ -316,29 +316,78 @@ public class JavaPropertiesResourceTest {
                 {"Log shows '{'}' in file {0}","Log shows '{'}'' in file {0}"},
                 {"Log shows '{'error'}' in file {0}","Log shows '{'error'}' in file {0}"},
                 {"Log shows '{''error''}' in file {0}","Log shows '{''error''}' in file {0}"},
-                {"File {0} shows '{''error''}'","File {0} shows '{''error''}'"}
+                {"File {0} shows '{''error''}'","File {0} shows '{''error''}'"},
         };
-     
-    @Test    
-    public void testConvertDoubleSingleQuote(){
-        for (String[] testCase : QUOTES_TEST_CASES) {
-            String instr = testCase[1];
-            String expected = testCase[0];
 
-            String doubleQuoteVal = JavaPropertiesResource.ConvertDoubleSingleQuote(instr);
-            assertEquals("ConvertDoubleSingleQuote(" + instr + ")", expected, doubleQuoteVal);
-        }
-    }
-    
+    private static final String[][] TO_DOUBLE_AUTO_TEST_CASES =
+        {
+            //  { input , expected }
+                {"The file isn't in use.", "The file isn't in use."},
+        };
+
+    private static final String[][] TO_DOUBLE_ALL_TEST_CASES =
+        {
+            //  { input , expected }
+                {"The file isn't in use.", "The file isn''t in use."},
+        };
+
+    private static final String[][] TO_SINGLE_AUTO_TEST_CASES =
+        {
+            //  { input , expected }
+                {"File {0} isn't in use.", "File {0} isn't in use."},
+                {"The file isn''t in use.", "The file isn''t in use."}, // no arguments - not unescaped
+        };
+
+    private static final String[][] TO_SINGLE_ALL_TEST_CASES =
+        {
+            //  { input , expected }
+                {"File {0} isn't in use.", "File {0} isn't in use."},
+                {"The file isn''t in use.", "The file isn't in use."},
+        };
+
     @Test
     public void testConvertSingleQuote(){
         for (String[] testCase : QUOTES_TEST_CASES) {
-            String instr = testCase[0];
-            String expected = testCase[1];
+            String result = JavaPropertiesResource.ConvertSingleQuote(testCase[0], MessagePatternEscape.AUTO);
+            assertEquals("ConvertSingleQuote(" + testCase[0] + ", AUTO)", testCase[1], result);
+        }
 
-            String doubleQuoteVal = JavaPropertiesResource.ConvertSingleQuote(instr);
-            assertEquals("ConvertSingleQuote(" + instr + ")", expected, doubleQuoteVal);
+        for (String[] testCase : QUOTES_TEST_CASES) {
+            String result = JavaPropertiesResource.ConvertSingleQuote(testCase[0], MessagePatternEscape.ALL);
+            assertEquals("ConvertSingleQuote(" + testCase[0] + ", ALL)", testCase[1], result);
+        }
+
+        for (String[] testCase : TO_DOUBLE_AUTO_TEST_CASES) {
+            String result = JavaPropertiesResource.ConvertSingleQuote(testCase[0], MessagePatternEscape.AUTO);
+            assertEquals("ConvertSingleQuote(" + testCase[0] + ", AUTO)", testCase[1], result);
+        }
+
+        for (String[] testCase : TO_DOUBLE_ALL_TEST_CASES) {
+            String result = JavaPropertiesResource.ConvertSingleQuote(testCase[0], MessagePatternEscape.ALL);
+            assertEquals("ConvertSingleQuote(" + testCase[0] + ", ALL)", testCase[1], result);
         }
     }
-    
+
+    @Test
+    public void testConvertDoubleSingleQuoteAuto(){
+        for (String[] testCase : QUOTES_TEST_CASES) {
+            String result = JavaPropertiesResource.ConvertDoubleSingleQuote(testCase[1], MessagePatternEscape.AUTO);
+            assertEquals("ConvertDoubleSingleQuote(" + testCase[1] + ", AUTO)", testCase[0], result);
+        }
+
+        for (String[] testCase : QUOTES_TEST_CASES) {
+            String result = JavaPropertiesResource.ConvertDoubleSingleQuote(testCase[1], MessagePatternEscape.ALL);
+            assertEquals("ConvertDoubleSingleQuote(" + testCase[1] + ", ALL)", testCase[0], result);
+        }
+
+        for (String[] testCase : TO_SINGLE_AUTO_TEST_CASES) {
+            String result = JavaPropertiesResource.ConvertDoubleSingleQuote(testCase[0], MessagePatternEscape.AUTO);
+            assertEquals("ConvertDoubleSingleQuote(" + testCase[0] + ", AUTO)", testCase[1], result);
+        }
+
+        for (String[] testCase : TO_SINGLE_ALL_TEST_CASES) {
+            String result = JavaPropertiesResource.ConvertDoubleSingleQuote(testCase[0], MessagePatternEscape.ALL);
+            assertEquals("ConvertDoubleSingleQuote(" + testCase[0] + ", ALL)", testCase[1], result);
+        }
+    }
 }

--- a/gp-res-filter/src/test/java/com/ibm/g11n/pipeline/resfilter/impl/JavaUTF8PropertiesResourceTest.java
+++ b/gp-res-filter/src/test/java/com/ibm/g11n/pipeline/resfilter/impl/JavaUTF8PropertiesResourceTest.java
@@ -42,6 +42,8 @@ import com.ibm.g11n.pipeline.resfilter.LanguageBundleBuilder;
 import com.ibm.g11n.pipeline.resfilter.ResourceFilterException;
 import com.ibm.g11n.pipeline.resfilter.ResourceString;
 import com.ibm.g11n.pipeline.resfilter.ResourceString.ResourceStringComparator;
+import com.ibm.g11n.pipeline.resfilter.impl.JavaPropertiesResource.Encoding;
+import com.ibm.g11n.pipeline.resfilter.impl.JavaPropertiesResource.MessagePatternEscape;
 import com.ibm.g11n.pipeline.resfilter.impl.JavaPropertiesResource.PropDef;
 import com.ibm.g11n.pipeline.resfilter.impl.JavaPropertiesResource.PropDef.PropSeparator;
 
@@ -147,7 +149,7 @@ public class JavaUTF8PropertiesResourceTest {
         EXPECTED_PROP_DEF_LIST.add(new PropDef("withTabs", "Tab1\tTab2\tTab3\t", PropSeparator.EQUAL));
     }
 
-    private static final JavaPropertiesResource res = new JavaPropertiesResource(true);
+    private static final JavaPropertiesResource res = new JavaPropertiesResource(Encoding.UTF_8, MessagePatternEscape.AUTO);
 
     @Test
     public void testParse() throws IOException, ResourceFilterException {


### PR DESCRIPTION
Fixed a Java properties file parsing problem cased by
JavaPropertiesResource#ConvertDoubleSingleQuote() when only standalone
single quote is used.

Added new resource types JAVAMSG and JAVAMSGUTF8 for supporting Java
MessageFormat pattern strings only strings, in addition to existing
JAVA/JAVAUTF8. The new types assumes resource strings are consumed by
Java MessageFormat even they do not have any arguments.

Fixed #105.