### PR TITLE
Silence json test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
       - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
 
 after_success:
-  - mvn clean cobertura:cobertura org.eluder.coveralls:coveralls-maven-plugin:report
+  - mvn clean cobertura:cobertura org.eluder.coveralls:coveralls-maven-plugin:report -Dcobertura.report.format=xml
 
 addons:
   coverity_scan:

--- a/gp-res-filter/src/test/java/com/ibm/g11n/pipeline/resfilter/impl/JsonResourceTest.java
+++ b/gp-res-filter/src/test/java/com/ibm/g11n/pipeline/resfilter/impl/JsonResourceTest.java
@@ -166,12 +166,6 @@ public class JsonResourceTest {
         }
     }
 
-    // @Test
-    // public void testTestFiles() throws IOException, ResourceFilterException {
-    // // just test the test files
-    // ResourceTestUtil.compareFilesJson(INPUT_FILE, EXPECTED_WRITE_FILE);
-    // }
-
     @Test
     public void testReWrite() throws IOException, ResourceFilterException {
         // First parse
@@ -208,18 +202,14 @@ public class JsonResourceTest {
             LanguageBundle bundle = res2.parse(is, null);
             List<ResourceString> resStrList = new ArrayList<>(bundle.getResourceStrings());
             Collections.sort(resStrList, new ResourceStringComparator());
-            // assertEquals("ResourceStrings did not match.",
-            // EXPECTED_INPUT_RES_LIST, resStrList);
 
             // Now write
             File tempFile = File.createTempFile(this.getClass().getSimpleName(), "3.json");
-            // File tempFile = new File("/tmp/3.json");
             tempFile.deleteOnExit();
 
             try (OutputStream os = new FileOutputStream(tempFile)) {
                 res.write(os, bundle, null);
                 os.flush();
-                System.out.println(ResourceTestUtil.fileToString(tempFile));
                 ResourceTestUtil.compareFilesJson(INPUT_FILE2, tempFile);
             }
         }

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,6 @@
 					<artifactId>cobertura-maven-plugin</artifactId>
 					<version>2.7</version>
 					<configuration>
-						<format>xml</format>
 						<maxmem>256m</maxmem>
 						<!-- aggregated reports for multi-module projects -->
 						<aggregate>true</aggregate>


### PR DESCRIPTION
- remove stray `System.out.println`  in test
- don't default the cobertura report format in the toplevel pom.xml (prevents overriding)