### PR TITLE
Make JAVAMSG and JAVAMSGUTF8 as java type

### DIFF
--- a/gp-res-filter/src/main/java/com/ibm/g11n/pipeline/resfilter/impl/DefaultResourceFilterProvider.java
+++ b/gp-res-filter/src/main/java/com/ibm/g11n/pipeline/resfilter/impl/DefaultResourceFilterProvider.java
@@ -140,6 +140,7 @@ public class DefaultResourceFilterProvider extends ResourceFilterProvider {
     // of ResourceFilter/MultiBundleResourceFilter interface instead. Revisit this later.
     public static boolean isJavaType(String type) {
         type = type.toUpperCase(Locale.ROOT);
-        return type.equals(Filter.JAVA.name()) || type.equals(Filter.JAVAUTF8.name());
+        return type.equals(Filter.JAVA.name()) || type.equals(Filter.JAVAUTF8.name())
+                || type.equals(Filter.JAVAMSG.name()) || type.equals(Filter.JAVAMSGUTF8.name());
     }
 }


### PR DESCRIPTION
JAVAMSG/JAVAMSGUTF8 type in resource filter should be handled as java
types, and use the same bundle name - file path mapping logic with
JAVA/JAVAMSG types. Fixes #126.