### PR TITLE
Fixing maven integration test issues

### DIFF
--- a/gp-maven-plugin/src/it/download-basic/pom.xml
+++ b/gp-maven-plugin/src/it/download-basic/pom.xml
@@ -34,6 +34,11 @@
 								</includes>
 							</sourceFiles>
 							<type>JSON</type>
+							<sourceLanguage>en</sourceLanguage>
+							<targetLanguages>
+								<param>de</param>
+								<param>fr</param>
+							</targetLanguages>
 						</bundleSet>
 					</bundleSets>
 				</configuration>

--- a/gp-maven-plugin/src/it/download-basic/verify.groovy
+++ b/gp-maven-plugin/src/it/download-basic/verify.groovy
@@ -36,7 +36,7 @@ try {
             }
         }
     }
-    assert filecount == 20
+    assert filecount == 6
 
     def dir2 = new File(targetLocation2)
     dir2.traverse { file ->

--- a/gp-maven-plugin/src/main/java/com/ibm/g11n/pipeline/maven/GPBaseMojo.java
+++ b/gp-maven-plugin/src/main/java/com/ibm/g11n/pipeline/maven/GPBaseMojo.java
@@ -263,8 +263,11 @@ public abstract class GPBaseMojo extends AbstractMojo {
                 Map<String, Set<String>> activeMTLangs = client.getConfiguredMTLanguages();
                 targetLanguages = activeMTLangs.get(srcLang);
             } catch (ServiceException e) {
-                targetLanguages = Collections.emptySet();
                 throw new MojoFailureException("Globalization Pipeline service error", e);
+            }
+
+            if (targetLanguages == null) {
+                targetLanguages = Collections.emptySet();
             }
 
             getLog().info("The configuration parameter 'targetLanguages' is not specified."


### PR DESCRIPTION
- When MT configuraton for English is not available, returns empty target language set, instead of null
- download-basic test to specify target languages explicitly instead of default MT languages that can be changed depending on GP deployments.